### PR TITLE
Branch view page and table rework

### DIFF
--- a/src/api/mock/data/db.json
+++ b/src/api/mock/data/db.json
@@ -135,23 +135,6 @@
   ],
   "fixtures": [
     {
-      "id": "fixture-1234",
-      "branchId": "branch-1234",
-      "name": "Source",
-      "occupancy": "",
-      "fixtureType": "",
-      "slug": "",
-      "loadValues": {
-        "cold": 0,
-        "hot": 0,
-        "total": 0
-      },
-      "shorthand": {
-        "occupancy": "",
-        "fixtureType": ""
-      }
-    },
-    {
       "id": "5b6998e0-dd85-11ee-9d65-1fb1c297f15e",
       "branchId": "branch-1234",
       "name": "Bathroom Group",
@@ -393,6 +376,55 @@
         "occupancy": "Pu.",
         "fixtureType": "Auto",
         "name": "Wash. Mach. 15lb"
+      }
+    },
+    {
+      "id": "787493d0-e30d-11ee-89ca-0336dba3a5da",
+      "branchId": "branch-1234",
+      "name": "Bathroom Group",
+      "occupancy": "Private",
+      "fixtureType": "Flush Tank",
+      "loadValues": {
+        "cold": 2.7,
+        "hot": 1.5,
+        "total": 3.6
+      },
+      "shorthand": {
+        "occupancy": "Pr.",
+        "fixtureType": "FT"
+      }
+    },
+    {
+      "id": "797784e0-e30d-11ee-89ca-0336dba3a5da",
+      "branchId": "branch-1234",
+      "name": "Bathtub",
+      "occupancy": "Private",
+      "fixtureType": "Faucet",
+      "slug": "bathtub-private-faucet",
+      "loadValues": {
+        "cold": 1,
+        "hot": 1,
+        "total": 1.4
+      },
+      "shorthand": {
+        "occupancy": "Pr.",
+        "fixtureType": "Fa."
+      }
+    },
+    {
+      "id": "d837a730-e30d-11ee-89ca-0336dba3a5da",
+      "branchId": "branch-1234",
+      "name": "Bathroom Group",
+      "occupancy": "Private",
+      "fixtureType": "Flush Tank",
+      "loadValues": {
+        "cold": 2.7,
+        "hot": 1.5,
+        "total": 3.6
+      },
+      "shorthand": {
+        "occupancy": "Pr.",
+        "fixtureType": "FT"
       }
     }
   ]

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,8 @@ import Accordion from 'primevue/accordion';
 import AccordionTab from 'primevue/accordiontab';
 import Toast from 'primevue/toast';
 import ToastService from 'primevue/toastservice';
+import InputGroup from 'primevue/inputgroup';
+import InputGroupAddon from 'primevue/inputgroupaddon';
 
 
 import App from './App.vue'
@@ -43,6 +45,8 @@ app.component('InputText', InputText)
 app.component('Accordion', Accordion)
 app.component('AccordionTab', AccordionTab)
 app.component('Toast', Toast)
+app.component('InputGroup', InputGroup)
+app.component('InputGroupAddon', InputGroupAddon)
 app.use(createPinia())
 
 app.mount('#app')

--- a/src/views/BranchView.vue
+++ b/src/views/BranchView.vue
@@ -34,6 +34,7 @@ const firstFixture = computed(() => {
 const rowClass = (data) => {
     return ['row'];
 };
+
 </script>
 
 <template>
@@ -66,50 +67,39 @@ const rowClass = (data) => {
                                     :min-fraction-digits="1" 
                                     :max-fraction-digits="1"
                                     placeholder="Initial Hot FUs"
-                    ></InputNumber>
+                                ></InputNumber>
                             </InputGroup>
                             <InputGroup class="input-group">
                                 <InputGroupAddon>
                                     Cold
                                 </InputGroupAddon>
-                    <InputNumber 
-                        id="init-value-input--cold"
-                        v-model="initColdValue" 
-                        @update:model-value="branchFixturesStore.updateLoads(initColdValue, initHotValue)"
-                        :min-fraction-digits="1" 
-                        :max-fraction-digits="1"
+                                <InputNumber 
+                                    id="init-value-input--cold"
+                                    v-model="initColdValue" 
+                                    @update:model-value="branchFixturesStore.updateLoads(initColdValue, initHotValue)"
+                                    :min-fraction-digits="1" 
+                                    :max-fraction-digits="1"
                                     placeholder="Initial Cold FUs"
-                    ></InputNumber>
+                                ></InputNumber>
                             </InputGroup>
                         <Button class="header__button">Add Fixture</Button>
                         </div>
                     </div>
-            </template>
-        </Card>
-        <div class="workspace">
-            <template v-if="calculatedFixtures.length">
-                <DataTable 
-                    :value="calculatedFixtures" 
-                    tableStyle="min-width: 50rem"
-                    class="table"
-                    :rowClass="rowClass"
-                >
-                    <Column field="name" header="Name">
-                        <template #body="slotProps">
-                            <div class="column-wrapper">
+                </template>
+                <Column field="name" header="Name">
+                    <template #body="slotProps">
+                        <div class="column-wrapper">
                             <h4 class="fixture__name">{{ slotProps.data.name }}</h4>
                             <p v-if="slotProps.data.occupancy" class="fixture__text">{{ slotProps.data.occupancy }} - {{ slotProps.data.fixtureType }}</p>
-                            </div>
-                        </template>
-                    </Column>
-                    <Column field="totals.loadValues.hot" header="Hot FUs"></Column>
-                    <Column field="totals.loadValues.cold" header="Cold FUs"></Column>
-                    <Column field="totals.sizes.hot" header="Hot Size"></Column>
-                    <Column field="totals.sizes.cold" header="Cold Size"></Column>
-                </DataTable>
-                <Button @click="fixtureSidebarStore.toggle" class="add-fixture-btn">Add Fixture</Button>
-            </template>
-        </div>
+                        </div>
+                    </template>
+                </Column>
+                <Column field="totals.loadValues.hot" header="Hot FUs"></Column>
+                <Column field="totals.loadValues.cold" header="Cold FUs"></Column>
+                <Column field="totals.sizes.hot" header="Hot Size"></Column>
+                <Column field="totals.sizes.cold" header="Cold Size"></Column>
+            </DataTable>
+        </template>
     </div>
     <FixtureSidebar></FixtureSidebar>
 </div>

--- a/src/views/BranchView.vue
+++ b/src/views/BranchView.vue
@@ -65,19 +65,25 @@ const rowClass = (data) => {
                                     @update:model-value="branchFixturesStore.updateLoads(initColdValue, initHotValue)"
                                     :min-fraction-digits="1" 
                                     :max-fraction-digits="1"
+                                    placeholder="Initial Hot FUs"
                     ></InputNumber>
-                    <label for="init-value-input--hot">Initial Hot Fixture Units</label>
-                </FloatLabel>
-                <FloatLabel class="init-value">
+                            </InputGroup>
+                            <InputGroup class="input-group">
+                                <InputGroupAddon>
+                                    Cold
+                                </InputGroupAddon>
                     <InputNumber 
                         id="init-value-input--cold"
                         v-model="initColdValue" 
                         @update:model-value="branchFixturesStore.updateLoads(initColdValue, initHotValue)"
                         :min-fraction-digits="1" 
                         :max-fraction-digits="1"
+                                    placeholder="Initial Cold FUs"
                     ></InputNumber>
-                    <label for="init-value-input--cold">Initial Cold Fixture Units</label>
-                </FloatLabel>
+                            </InputGroup>
+                        <Button class="header__button">Add Fixture</Button>
+                        </div>
+                    </div>
             </template>
         </Card>
         <div class="workspace">

--- a/src/views/BranchView.vue
+++ b/src/views/BranchView.vue
@@ -97,9 +97,8 @@ const rowClass = (data) => {
                     <Column field="name" header="Name">
                         <template #body="slotProps">
                             <div class="column-wrapper">
-                                <h4 class="riser__name">{{ slotProps.data.name }}</h4>
-                                <p class="riser__text">{{ slotProps.data.occupancy }}</p>
-                                <p class="riser__text">{{ slotProps.data.fixtureType }}</p>
+                            <h4 class="fixture__name">{{ slotProps.data.name }}</h4>
+                            <p v-if="slotProps.data.occupancy" class="fixture__text">{{ slotProps.data.occupancy }} - {{ slotProps.data.fixtureType }}</p>
                             </div>
                         </template>
                     </Column>

--- a/src/views/BranchView.vue
+++ b/src/views/BranchView.vue
@@ -8,6 +8,7 @@ import FixtureSidebar from '../components/FixtureSidebar.vue'
 
 const fixtureSidebarStore = useFixtureSidebarStore()
 const branchFixturesStore = useBranchFixturesStore()
+const { getFixtures } = useBranchFixturesStore()
 
 const { params } = useRoute()
 

--- a/src/views/BranchView.vue
+++ b/src/views/BranchView.vue
@@ -116,11 +116,26 @@ const rowClass = (data) => {
 </template>
 
 <style scoped>
+.table {
+    position: relative;
+}
+
+.card {
+    box-shadow: none;
+}
+
 .table:deep .row {
     animation: show 750ms 100ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
     opacity: 0;
     height: 72px;
     position: relative;
+}
+
+.header-wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 3rem;
 }
 
 @keyframes show {

--- a/src/views/BranchView.vue
+++ b/src/views/BranchView.vue
@@ -6,7 +6,6 @@ import { useFixtureSidebarStore } from '@/stores/fixtureSidebar'
 import { useBranchFixturesStore } from '@/stores/branchFixtures'
 import FixtureSidebar from '../components/FixtureSidebar.vue'
 
-const fixtureSidebarStore = useFixtureSidebarStore()
 const branchFixturesStore = useBranchFixturesStore()
 const { getFixtures } = useBranchFixturesStore()
 

--- a/src/views/BranchView.vue
+++ b/src/views/BranchView.vue
@@ -27,7 +27,11 @@ onMounted(async () => {
 
 const { fixtures, calculatedFixtures, initColdValue, initHotValue } = storeToRefs(useBranchFixturesStore())
 
-const rowClass = () => {
+const firstFixture = computed(() => {
+    return fixtures.value.slice(0, 1)
+})
+
+const rowClass = (data) => {
     return ['row'];
 };
 </script>

--- a/src/views/BranchView.vue
+++ b/src/views/BranchView.vue
@@ -38,17 +38,33 @@ const rowClass = (data) => {
 
 <template>
   <div class="container">
-    <div class="content">
-        <Card class="card">
-            <template #title>Branch Initialization</template>
-            <template #content>
-                <FloatLabel class="init-value">
-                    <InputNumber 
-                        id="init-value-input--hot"
-                        v-model="initHotValue" 
-                        @update:model-value="branchFixturesStore.updateLoads(initColdValue, initHotValue)"
-                        :min-fraction-digits="1" 
-                        :max-fraction-digits="1"
+    <div class="content" ref="content">
+        <template v-if="calculatedFixtures.length && firstFixture.length">
+            <DataTable 
+                ref="fixturesTable"
+                :value="calculatedFixtures" 
+                tableStyle="min-width: 50rem"
+                class="table"
+                :rowClass="(data) => rowClass(data)"
+            >
+                <template #header ref="Header">
+                    <div class="header-wrapper">
+                        <div class="header__text">
+                            <p class="header__values"><span class="header__values__title">Cold:</span> {{ firstFixture[0].totals.loadValues.cold }} / {{ firstFixture[0].totals.sizes.cold }}</p>
+                            <p class="header__values"><span class="header__values__title">Hot:</span> {{ firstFixture[0].totals.loadValues.hot }} / {{ firstFixture[0].totals.sizes.hot }}</p> 
+                        </div>
+                        <div class="header__actions">
+                            <p>Init. Values</p>
+                            <InputGroup class="input-group">
+                                <InputGroupAddon>
+                                    Hot
+                                </InputGroupAddon>
+                                <InputNumber 
+                                    id="init-value-input--hot"
+                                    v-model="initHotValue" 
+                                    @update:model-value="branchFixturesStore.updateLoads(initColdValue, initHotValue)"
+                                    :min-fraction-digits="1" 
+                                    :max-fraction-digits="1"
                     ></InputNumber>
                     <label for="init-value-input--hot">Initial Hot Fixture Units</label>
                 </FloatLabel>

--- a/src/views/BranchView.vue
+++ b/src/views/BranchView.vue
@@ -168,28 +168,69 @@ const rowClass = (data) => {
     background: var(--surface-ground);
 }
 
-.add-fixture-btn {
-    margin: 2rem 0;
+.total-card-wrapper {
+    position: sticky;
+    top: 0rem;
+    z-index: 1000;
+    box-shadow: none;
+    background: var(--surface-ground);
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2rem;
+    width: 100%;
+}
+
+.totalCard {
+    box-shadow: none;
+    width: 100%;
 }
 
 .init-value {
-    margin: 3rem 0;
+    margin: 1.5rem 0 0;
 }
 
-.init-value:last-child {
-    margin-bottom: 1rem;
+.table:deep(.row--first) {
+    width: 100%;
+    z-index: 1000;
+    background: white;
+}
+
+.table:deep(.row--first td) {
+    background: white;
+}
+
+.table:deep(.p-datatable-header) {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+}
+
+.table:deep(.p-datatable-wrapper) {
+    height: 100%;
+    overflow-y: auto;
+    position: relative;
+}
+
+.table:deep(.p-datatable-thead) {
+    /* position: sticky; */
+    top: 0;
+    z-index: 100;
 }
 
 .content {
+    display: flex;
+    flex-direction: column;
     flex: calc(100% - 360px) 1 1;
     height: 100vh;
-    overflow: auto;
-    padding: 4rem;
+    overflow: hidden;
+    padding: 3rem;
     max-width: 100vw;
+    gap: 3rem;
+    position: relative;
 }
 
 .workspace {
-    margin-top: 4rem;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -199,8 +240,17 @@ const rowClass = (data) => {
 .table {
     width: 100%;
     border-radius: 12px;
+    position: relative;
+    height: 100%;
     overflow: hidden;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+}
+
+.table.flat {
+    box-shadow: none;
+}
+
+.table.flat:deep(tr) {
+    height: 3rem;
 }
 
 .table table {
@@ -210,5 +260,62 @@ const rowClass = (data) => {
 .table table tr {
     border: 1px solid #e2e8f0;
     border-collapse: collapse;
+}
+
+.total-card-wrapper:before {
+    content: "";
+    height: 3rem;
+    position: absolute;
+    top: -3rem;
+    background: var(--surface-ground);
+    width: 100%;
+    z-index: 10;
+}
+
+.total-card-wrapper:after {
+    content: "";
+    height: 3rem;
+    position: absolute;
+    bottom: -3rem;
+    background: var(--surface-ground);
+    width: 100%;
+    z-index: 10;
+}
+
+.column-wrapper * {
+    margin: 0.5rem 0;
+}
+
+.card-content-wrapper {
+    display: flex;
+    gap: 3rem;
+}
+
+.total-text {
+    font-weight: bold;
+}
+
+.header__values {
+    font-weight: normal;
+}
+
+.input-group {
+    width: auto;
+    height: 38px;
+}
+
+.header__actions {
+    display: flex;
+    gap: 2rem;
+    align-items: center;
+} 
+
+.header__text {
+    display: flex;
+    gap: 2rem;
+}
+
+.header__values__title {
+    font-weight: bold;
 }
 </style>

--- a/src/views/BranchView.vue
+++ b/src/views/BranchView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router';
 import { storeToRefs } from 'pinia'
 import { useFixtureSidebarStore } from '@/stores/fixtureSidebar'

--- a/src/views/BranchView.vue
+++ b/src/views/BranchView.vue
@@ -12,7 +12,10 @@ const { getFixtures } = useBranchFixturesStore()
 
 const { params } = useRoute()
 
-const { getFixtures } = useBranchFixturesStore()
+
+const fixturesTable = ref(null)
+const headerHeight = ref(0)
+
 
 onMounted(async () => {
     await getFixtures(params.branch_id)

--- a/src/views/BranchView.vue
+++ b/src/views/BranchView.vue
@@ -19,6 +19,10 @@ const headerHeight = ref(0)
 
 onMounted(async () => {
     await getFixtures(params.branch_id)
+    const header = fixturesTable.value.$el.querySelector('.p-datatable-header')
+    const table = fixturesTable.value.$el.querySelector('.p-datatable-table') 
+    headerHeight.value = header.offsetHeight
+    table.style = "padding-bottom: " + headerHeight.value + "px;"
 })
 
 const { fixtures, calculatedFixtures, initColdValue, initHotValue } = storeToRefs(useBranchFixturesStore())


### PR DESCRIPTION
Remove separated cards displaying data. 
Page is just one table with a header displaying totals and actions (initialization inputs and add fixture button)
Header and subheader are frozen and stick when scrolling. Table needed a bottom padding of 77px to account for the sticky header height. Bottom padding is dynamic and references the header's offset height