### PR TITLE
Connect-branches-store-to-api

### DIFF
--- a/src/components/TitleHeader.vue
+++ b/src/components/TitleHeader.vue
@@ -10,6 +10,9 @@ const { params } = useRoute()
 const { getProject, getRiserLabel} = useProjectStore()
 const { getBranch } = useBranchesStore()
 
+const riserLabel = ref("")
+const branchLabel = ref("")
+
 onMounted(async () => {
     if(params.project_id) {
         await getProject(params.project_id)

--- a/src/components/TitleHeader.vue
+++ b/src/components/TitleHeader.vue
@@ -7,7 +7,7 @@ import { useRoute } from "vue-router";
 
 const { params } = useRoute()
 
-const { getProject, getRiserLabel} = useProjectStore()
+const { getProject, getRiser } = useProjectStore()
 const { getBranch } = useBranchesStore()
 
 const riserLabel = ref("")
@@ -18,7 +18,9 @@ onMounted(async () => {
         await getProject(params.project_id)
     }
     if(params.riser_id) {
-        await getRiserLabel(params.riser_id)
+        await getRiser(params.riser_id)
+        if(!riser.value) return;
+        riserLabel.value = riser.value.label
     }
     if(params.branch_id) {
         await getBranch(params.branch_id)

--- a/src/components/TitleHeader.vue
+++ b/src/components/TitleHeader.vue
@@ -24,6 +24,7 @@ onMounted(async () => {
     }
     if(params.branch_id) {
         await getBranch(params.branch_id)
+        branchLabel.value = branch.value.label
     }
 })
 

--- a/src/components/TitleHeader.vue
+++ b/src/components/TitleHeader.vue
@@ -2,7 +2,7 @@
 import { useBranchesStore } from "@/stores/branches";
 import { useProjectStore } from "@/stores/project"
 import { storeToRefs } from "pinia";
-import { onMounted } from "vue";
+import { ref, onMounted } from "vue";
 import { useRoute } from "vue-router";
 
 const { params } = useRoute()

--- a/src/components/TitleHeader.vue
+++ b/src/components/TitleHeader.vue
@@ -40,7 +40,7 @@ const { branch } = storeToRefs(useBranchesStore())
             <h3 class="text-gray-700 mt-0 mb-2">{{ project.name }}</h3>
             <p class="my-0">{{ project.address }}</p>
         </div>
-        <div v-if="params.riser_id && riserLabel" class="flex flex-column align-items-start justify-content-center">
+        <div v-if="params.riser_id && riser" class="flex flex-column align-items-start justify-content-center">
             <h3 class="text-gray-700 mt-0 mb-2">Riser Label</h3>
             <p class="my-0">{{ riserLabel }}</p>
         </div>

--- a/src/components/TitleHeader.vue
+++ b/src/components/TitleHeader.vue
@@ -28,10 +28,8 @@ onMounted(async () => {
     }
 })
 
-const { project, riserLabel } = storeToRefs(useProjectStore())
 const { branch } = storeToRefs(useBranchesStore())
-
-
+const { project, riser } = storeToRefs(useProjectStore())
 
 </script>
 <template>

--- a/src/components/TitleHeader.vue
+++ b/src/components/TitleHeader.vue
@@ -46,7 +46,7 @@ const { branch } = storeToRefs(useBranchesStore())
         </div>
         <div v-if="params.branch_id && branch" class="flex flex-column align-items-start justify-content-center">
             <h3 class="text-gray-700 mt-0 mb-2">Branch Label</h3>
-            <p class="my-0">{{ branch.label }}</p>
+            <p class="my-0">{{ branchLabel }}</p>
         </div>
     </header>
 </template>

--- a/src/stores/branches.ts
+++ b/src/stores/branches.ts
@@ -10,7 +10,7 @@ export const useBranchesStore = defineStore('branches-store', () => {
 
   const getBranches = async (riserId) => {
     try {
-      await fetch(`http://localhost:3000/branches?riserId=${riserId}`)
+      await fetch(`http://localhost:8080/branches?riserId=${riserId}`)
         .then((response) => 
           response.json()
         )

--- a/src/stores/branches.ts
+++ b/src/stores/branches.ts
@@ -40,7 +40,6 @@ export const useBranchesStore = defineStore('branches-store', () => {
     const { label, startingFloor, riserId } = branchObj; 
 
     const body = {
-      id: uuidv4(),
       riserId,
       label,
       startingFloor,

--- a/src/stores/branches.ts
+++ b/src/stores/branches.ts
@@ -64,5 +64,21 @@ export const useBranchesStore = defineStore('branches-store', () => {
     }
   }
 
-  return { branches, getBranches, branch, getBranch, postBranch }
+  const deleteBranch = async (branchId) => {
+
+    try {
+      await fetch(`http://localhost:8080/branches/${branchId}`,
+      {
+        method: "DELETE"
+      })
+      .then((res) => res.json())
+      .then((data) => {
+        branches.value = branches.value.filter(branch => branch.id != data.id)
+      })
+    } catch (error) {
+        console.log(error);
+    }
+  }
+
+  return { branches, getBranches, branch, getBranch, postBranch, deleteBranch }
 })

--- a/src/stores/branches.ts
+++ b/src/stores/branches.ts
@@ -46,7 +46,7 @@ export const useBranchesStore = defineStore('branches-store', () => {
     }
 
     try {
-      await fetch(`http://localhost:3000/branches`, 
+      await fetch(`http://localhost:8080/branches`, 
       {
         method: "POST",
         headers: {

--- a/src/stores/project.ts
+++ b/src/stores/project.ts
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from "uuid";
 export const useProjectStore = defineStore('project-store', () => {
   const project = ref(null)
   const riserLabel = ref(null)
+  const riser = ref(null)
 
   const getProject = async (projectId) => {
     try {
@@ -17,6 +18,20 @@ export const useProjectStore = defineStore('project-store', () => {
         })
     } catch (error) {
       console.error(error);
+    }
+  }
+
+  const getRiser = async (riserId) => {
+    try {
+      await fetch(`http://localhost:8080/risers/${riserId}`)
+        .then((response) => 
+          response.json()
+        )
+        .then((data) => {
+          riser.value = data
+        })
+      } catch (error) {
+        console.error(error);
     }
   }
 
@@ -82,5 +97,5 @@ export const useProjectStore = defineStore('project-store', () => {
     }
   }
 
-  return { project, riserLabel, getProject, getRiserLabel, postRiser, deleteRiser }
+  return { project, riser, riserLabel, getProject, getRiser, getRiserLabel, postRiser, deleteRiser }
 })

--- a/src/views/RiserView.vue
+++ b/src/views/RiserView.vue
@@ -58,6 +58,10 @@ const createBranch = async () => {
     return toggleCreateDialog()
 }
 
+const deleteBranch = async (branchId) => {
+    await branchesStore.deleteBranch(branchId)
+}
+
 </script>
 <template>
     <main>

--- a/src/views/RiserView.vue
+++ b/src/views/RiserView.vue
@@ -88,7 +88,7 @@ const deleteBranch = async (branchId) => {
                             <Column>
                                 <template #body="slotProps">
                                     <div class="actions">
-                                        <Button class="actions__button" icon="pi pi-trash" severity="danger"></Button>
+                                        <Button @click="deleteBranch(slotProps.data.id)" class="actions__button" icon="pi pi-trash" severity="danger"></Button>
                                         <Button class="actions__button">
                                             <router-link :to="'/projects/' + slotProps.data.id"><i class="pi pi-external-link" style="color: white;"></i></router-link>
                                         </Button>

--- a/src/views/RiserView.vue
+++ b/src/views/RiserView.vue
@@ -74,6 +74,8 @@ const deleteBranch = async (branchId) => {
                 <Card class="card">
                     <template v-if="branches" #content>
                         <DataTable :value="branches">
+                            <template #empty> No branches found.</template>
+                            <template #loading> Loading customers data. Please wait. </template>
                             <Column field="label" header="Branch">
                                 <template #body="slotProps">
                                     <router-link :to="path + '/branches/' + slotProps.data.id">{{ slotProps.data.label }}</router-link>

--- a/src/views/RiserView.vue
+++ b/src/views/RiserView.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed, onMounted, reactive } from 'vue'
 import { useBranchesStore } from "@/stores/branches"
+import { useProjectStore } from "@/stores/project"
 import { useRoute } from 'vue-router';
 import BackLink from '@/components/BackLink.vue';
 import TitleHeader from '@/components/TitleHeader.vue';
@@ -8,6 +9,7 @@ import { useVuelidate } from '@vuelidate/core'
 import { helpers, required } from '@vuelidate/validators'
 
 const branchesStore = useBranchesStore()
+const projectStore = useProjectStore()
 
 const createDialogVisible = ref(false)
 
@@ -27,6 +29,7 @@ const rules = {
 const v$ = useVuelidate(rules, form)
 
 onMounted(async () => {
+    await projectStore.getRiser(params.riser_id)
     await branchesStore.getBranches(params.riser_id)
     backLink.value = "/projects/" + params.project_id
 })


### PR DESCRIPTION
Users can now see branches for the current riser on the riser view. If there aren't any branches, then table has an empty message. Users can now also create branches and delete branches. It's all hooked up to the node api.